### PR TITLE
Add mimemagic ref in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,4 +64,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'cloudinary', '~> 1.16.0'
 gem 'geocoder'
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
 gem 'pundit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -123,7 +130,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -267,6 +273,7 @@ DEPENDENCIES
   geocoder
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  mimemagic!
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails


### PR DESCRIPTION
# Problem
I wasn't able to run `bundle install` after cloning the repo

# Solution
After their license changes mentioned [here](https://stackoverflow.com/questions/66919504/your-bundle-is-locked-to-mimemagic-0-3-5-but-that-version-could-not-be-found), the solution is basically setting a reference commit for the gem.

## Error I encountered
```
Your bundle is locked to mimemagic (0.3.5), but that version could not be found in any of the sources listed in your
Gemfile. If you haven't changed sources, that means the author of mimemagic (0.3.5) has removed it. You'll need to
update your bundle to a version other than mimemagic (0.3.5) that hasn't been removed in order to install.
```

## Sidenote
Would you kindly add `hacktoberfest-accepted` label to this PR or `hacktoberfest` to the topic of the repository so it counts? 😁 

### Happy hacktober fest! 🎉 